### PR TITLE
Add timestamp to filename

### DIFF
--- a/AtomGPS_wigler.ino
+++ b/AtomGPS_wigler.ino
@@ -59,7 +59,7 @@ void initializeFile() {
   bool isNewFile = false;
 
   // create a date stamp for the filename
-  char fileDateStamp[12];
+  char fileDateStamp[16];
   sprintf(fileDateStamp, "%04d-%02d-%02d-",
           gps.date.year(), gps.date.month(), gps.date.day());
   

--- a/AtomGPS_wigler.ino
+++ b/AtomGPS_wigler.ino
@@ -57,8 +57,14 @@ void waitForGPSFix() {
 void initializeFile() {
   int fileNumber = 0;
   bool isNewFile = false;
+
+  // create a date stamp for the filename
+  char fileDateStamp[12];
+  sprintf(fileDateStamp, "%04d-%02d-%02d-",
+          gps.date.year(), gps.date.month(), gps.date.day());
+  
   do {
-    fileName = "/wifi-scans" + String(fileNumber) + ".csv";
+    fileName = "/wifi-scans-" + String(fileDateStamp) + String(fileNumber) + ".csv";
     isNewFile = !SD.exists(fileName);
     fileNumber++;
   } while (!isNewFile);

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ AtomGPS_wigler is a wardriving tool initially **created by @lozaning** using the
   
 ## Prerequisites
 - M5Stack Atom GPS Kit
-- TF Card
+  - Available at DigiKey - https://www.digikey.com/en/products/detail/m5stack-technology-co-ltd/K043/13148796
+- TF Card (4GB standard, tested up to 32GB)
 - ESPtool or Arduino IDE
 
 ## Installation


### PR DESCRIPTION
Since all files get created with default dates on the unit, get the current date from the GPS fix and use that in the filename. Each run gets the incremented number.

Also added readme reference to Digikey for the Atom unit