### PR TITLE
Add timestamps to filename, info to readme

### DIFF
--- a/AtomGPS_wigler.ino
+++ b/AtomGPS_wigler.ino
@@ -59,7 +59,7 @@ void initializeFile() {
   bool isNewFile = false;
 
   // create a date stamp for the filename
-  char fileDateStamp[12];
+  char fileDateStamp[16];
   sprintf(fileDateStamp, "%04d-%02d-%02d-",
           gps.date.year(), gps.date.month(), gps.date.day());
   

--- a/AtomGPS_wigler.ino
+++ b/AtomGPS_wigler.ino
@@ -57,8 +57,14 @@ void waitForGPSFix() {
 void initializeFile() {
   int fileNumber = 0;
   bool isNewFile = false;
+
+  // create a date stamp for the filename
+  char fileDateStamp[12];
+  sprintf(fileDateStamp, "%04d-%02d-%02d-",
+          gps.date.year(), gps.date.month(), gps.date.day());
+  
   do {
-    fileName = "/wifi-scans" + String(fileNumber) + ".csv";
+    fileName = "/wifi-scans-" + String(fileDateStamp) + String(fileNumber) + ".csv";
     isNewFile = !SD.exists(fileName);
     fileNumber++;
   } while (!isNewFile);

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ AtomGPS_wigler is a wardriving tool initially **created by @lozaning** using the
   
 ## Prerequisites
 - M5Stack Atom GPS Kit
-- TF Card
+  - Available at DigiKey - https://www.digikey.com/en/products/detail/m5stack-technology-co-ltd/K043/13148796
+- TF Card (4GB standard, tested up to 32GB)
 - ESPtool or Arduino IDE
 
 ## Installation


### PR DESCRIPTION
Add a timestamp to file names so we can see when they were created. Files on the SD all get default dates. The incremented run number is still appended for a unique filename.

Also added info on SD card and source for M5 Atom.